### PR TITLE
Correct the typo mistake of variable

### DIFF
--- a/library/Zend/Config/Yaml.php
+++ b/library/Zend/Config/Yaml.php
@@ -289,7 +289,7 @@ class Zend_Config_Yaml extends Zend_Config
     {
         $config   = array();
         $inIndent = false;
-        foreach ($line as $n => $line) {
+        foreach ($lines as $n => $line) {
             $lineno = $n + 1;
 
             $line = rtrim(preg_replace("/#.*$/", "", $line));


### PR DESCRIPTION
When this code will merge, it will correct the typo mistake of variable in codebase and resolve the error.